### PR TITLE
Fix the towncrier link

### DIFF
--- a/CHANGES/95.doc.rst
+++ b/CHANGES/95.doc.rst
@@ -1,0 +1,2 @@
+On the `CHANGES/README.rst <https://github.com/aio-libs/aioloop-proxy/tree/master/CHANGES/README.rst>`_ page,
+a link to the ``Towncrier philosophy`` has been fixed.

--- a/CHANGES/README.rst
+++ b/CHANGES/README.rst
@@ -83,4 +83,4 @@ File :file:`CHANGES/553.feature.rst`:
 
 
 .. _Towncrier philosophy:
-   https://towncrier.readthedocs.io/en/actual-freaking-docs/#philosophy
+   https://towncrier.readthedocs.io/en/stable/#philosophy


### PR DESCRIPTION
## What do these changes do?

These changes fix a broken link to `towncrier`'s philosophy.

## Are there changes in behavior for the user?

Link from [CHANGES/README.rst](https://github.com/aio-libs/aioloop-proxy/tree/master/CHANGES/README.rst) to `towncrier`'s philosophy will be fixed.

## Related issue number

Similar PR:
  * aio-libs/frozenlist#574

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes

_Best regards!_